### PR TITLE
try/catch for history baskets with deactivated products

### DIFF
--- a/src/Client/Html/Basket/Standard/Standard.php
+++ b/src/Client/Html/Basket/Standard/Standard.php
@@ -197,15 +197,24 @@ class Standard
 
 		if( ( $prodid = $view->param( 'b_prodid', '' ) ) !== '' && $view->param( 'b_quantity', 0 ) > 0 )
 		{
-			$basketCntl->addProduct(
-				$productCntl->get( $prodid ),
-				(float) $view->param( 'b_quantity', 0 ),
-				(array) $view->param( 'b_attrvarid', [] ),
-				$this->getAttributeMap( $view->param( 'b_attrconfid', [] ) ),
-				array_filter( (array) $view->param( 'b_attrcustid', [] ) ),
-				(string) $view->param( 'b_stocktype', 'default' ),
-				$view->param( 'b_siteid' )
-			);
+			try
+			{
+				$basketCntl->addProduct(
+					$productCntl->get( $prodid ),
+					(float) $view->param( 'b_quantity', 0 ),
+					(array) $view->param( 'b_attrvarid', [] ),
+					$this->getAttributeMap( $view->param( 'b_attrconfid', [] ) ),
+					array_filter( (array) $view->param( 'b_attrcustid', [] ) ),
+					(string) $view->param( 'b_stocktype', 'default' ),
+					$view->param( 'b_siteid' )
+				);
+			}
+			catch( \Exception $e )
+			{
+				//eg. product has been deactivated
+				$msg = $view->translate( 'client', "At least one product couldn't be added to the basket." );
+				$view->errors = array_merge( $view->get( 'errors', [] ), [$msg] );
+			}
 		}
 		else
 		{
@@ -213,14 +222,23 @@ class Standard
 			{
 				if( ( $values['prodid'] ?? null ) && ( $values['quantity'] ?? 0 ) > 0 )
 				{
-					$basketCntl->addProduct( $productCntl->get( $values['prodid'] ),
-						(float) ( $values['quantity'] ?? 0 ),
-						array_filter( (array) ( $values['attrvarid'] ?? [] ) ),
-						$this->getAttributeMap( (array) ( $values['attrconfid'] ?? [] ) ),
-						array_filter( (array) ( $values['attrcustid'] ?? [] ) ),
-						(string) ( $values['stocktype'] ?? 'default' ),
-						$values['siteid'] ?? null
-					);
+					try
+					{
+						$basketCntl->addProduct( $productCntl->get( $values['prodid'] ),
+							(float) ( $values['quantity'] ?? 0 ),
+							array_filter( (array) ( $values['attrvarid'] ?? [] ) ),
+							$this->getAttributeMap( (array) ( $values['attrconfid'] ?? [] ) ),
+							array_filter( (array) ( $values['attrcustid'] ?? [] ) ),
+							(string) ( $values['stocktype'] ?? 'default' ),
+							$values['siteid'] ?? null
+						);
+					}
+					catch( \Exception $e )
+					{
+						//eg. product has been deactivated
+						$msg = $view->translate( 'client', "At least one product couldn't be added to the basket." );
+						$view->errors = array_merge( $view->get( 'errors', [] ), [$msg] );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
customer adds a "history-basket" to his current basket

history-basket contains at least one deactivated product -> Error Eintrag mit ID "1234" in "product.id" nicht gefunden {"userId":1,"exception":"[object] (Aimeos\\MShop\\Exception(code: 404): Eintrag mit ID \"1234\" in \"product.id\" nicht gefunden at \\vendor\\aimeos\\aimeos-core\\src\\MShop\\Common\\Manager\\DB.php:635)